### PR TITLE
Measure latency in RDMA write-based microbenchmark

### DIFF
--- a/src/app/write_messaging.cc
+++ b/src/app/write_messaging.cc
@@ -101,7 +101,7 @@ void ClientMain() {
         }
         // Check for response
         rdmamsg::InboundMessage response = msg_ep->CheckInboundMessage();
-        while (response.size > 0) {
+        if (response.size > 0) {
             DCHECK_EQ(sizeof(unsigned long), response.size);
             // FIXME: when using `while` instead of `if`, this check sometimes fails at the
             // beginning of the inbound message buffer!
@@ -117,7 +117,6 @@ void ClientMain() {
                 msg_ep->ReleaseInboundMessageBuffer();
                 refresh_round = 0;
             }
-            response = msg_ep->CheckInboundMessage();
         }
     }
     auto end = std::chrono::steady_clock::now();

--- a/src/app/write_messaging.cc
+++ b/src/app/write_messaging.cc
@@ -104,8 +104,8 @@ void ClientMain() {
         // Check for response
         rdmamsg::InboundMessage response = msg_ep->CheckInboundMessage();
         while (response.size > 0) {
-            // DCHECK_EQ(sizeof(unsigned long), response.size);
-            // DCHECK_EQ(completed_round, *reinterpret_cast<unsigned long *>(response.data));
+            DCHECK_EQ(sizeof(unsigned long), response.size);
+            DCHECK_EQ(completed_round, *reinterpret_cast<volatile unsigned long *>(response.data));
             completed_round++;
             LOG_EVERY_N(INFO, FLAGS_round / 10)
                 << "Progress: " << completed_round << " / " << FLAGS_round;

--- a/src/app/write_messaging.cc
+++ b/src/app/write_messaging.cc
@@ -102,8 +102,9 @@ void ClientMain() {
         // Check for response
         rdmamsg::InboundMessage response = msg_ep->CheckInboundMessage();
         while (response.size > 0) {
-            // FIXME: these checks failed!
             DCHECK_EQ(sizeof(unsigned long), response.size);
+            // FIXME: when using `while` instead of `if`, this check sometimes fails at the
+            // beginning of the inbound message buffer!
             DCHECK_EQ(completed_round, *reinterpret_cast<volatile unsigned long *>(response.data));
             completed_round++;
             LOG_EVERY_N(INFO, FLAGS_round / 10)

--- a/src/app/write_messaging.cc
+++ b/src/app/write_messaging.cc
@@ -33,9 +33,8 @@ const size_t kMessageSize = 16;
 const size_t kLatencyMeasurePeriod = 101;
 
 void ServerMain() {
-    unsigned char *buffer = new unsigned char[kBufferSize]();
-    RdmaServer *rdma_server = new RdmaServer(nullptr, 0, reinterpret_cast<char *>(buffer),
-                                             kBufferSize, 128, 128, IBV_QPT_RC);
+    volatile unsigned char *buffer = new volatile unsigned char[kBufferSize]();
+    RdmaServer *rdma_server = new RdmaServer(nullptr, 0, buffer, kBufferSize, 128, 128, IBV_QPT_RC);
     rdma_server->Listen(FLAGS_endpoint.c_str());
     rdmamsg::RdmaWriteMessagingEndpoint *msg_ep =
         new rdmamsg::RdmaWriteMessagingEndpoint(rdma_server, buffer, kBufferSize);
@@ -73,9 +72,8 @@ void ClientMain() {
     LOG_IF(WARNING, FLAGS_round >= (1 << 16))
         << "This will run for " << FLAGS_round
         << " rounds. Consider using smaller rounds to measure latency to prevent other overhead.";
-    unsigned char *buffer = new unsigned char[kBufferSize]();
-    RdmaClient *rdma_client = new RdmaClient(nullptr, 0, reinterpret_cast<char *>(buffer),
-                                             kBufferSize, 128, 128, IBV_QPT_RC);
+    volatile unsigned char *buffer = new volatile unsigned char[kBufferSize]();
+    RdmaClient *rdma_client = new RdmaClient(nullptr, 0, buffer, kBufferSize, 128, 128, IBV_QPT_RC);
     rdma_client->Connect(FLAGS_endpoint.c_str());
     rdmamsg::RdmaWriteMessagingEndpoint *msg_ep =
         new rdmamsg::RdmaWriteMessagingEndpoint(rdma_client, buffer, kBufferSize);

--- a/src/app/write_messaging.cc
+++ b/src/app/write_messaging.cc
@@ -68,7 +68,7 @@ void ServerMain() {
 }
 
 void ClientMain() {
-    // TODO(jim90247): check the cause of high latency overhead when round is too large. Sudden
+    // TODO: check the cause of high latency overhead when round is too large. Sudden
     // increase in latency is observed when client wrap around the message buffer.
     LOG_IF(WARNING, FLAGS_round >= (1 << 16))
         << "This will run for " << FLAGS_round
@@ -104,7 +104,7 @@ void ClientMain() {
         // Check for response
         rdmamsg::InboundMessage response = msg_ep->CheckInboundMessage();
         while (response.size > 0) {
-            // FIXME(jim90247): these checks failed!
+            // FIXME: these checks failed!
             DCHECK_EQ(sizeof(unsigned long), response.size);
             DCHECK_EQ(completed_round, *reinterpret_cast<volatile unsigned long *>(response.data));
             completed_round++;

--- a/src/app/write_messaging.cc
+++ b/src/app/write_messaging.cc
@@ -58,7 +58,7 @@ void ServerMain() {
         }
 
         // Send response
-        *reinterpret_cast<unsigned long *>(
+        *reinterpret_cast<volatile unsigned long *>(
             msg_ep->AllocateOutboundMessageBuffer(sizeof(unsigned long))) = round;
         if (++flush_round >= FLAGS_outbound_batch) {
             msg_ep->FlushOutboundMessage();
@@ -84,7 +84,7 @@ void ClientMain() {
     while (completed_round < FLAGS_round) {
         // Send request
         if (sent_round < FLAGS_round) {
-            *reinterpret_cast<unsigned long *>(
+            *reinterpret_cast<volatile unsigned long *>(
                 msg_ep->AllocateOutboundMessageBuffer(sizeof(unsigned long))) = sent_round;
             sent_round++;
             if (++flush_round >= FLAGS_outbound_batch) {

--- a/src/app/write_messaging.cc
+++ b/src/app/write_messaging.cc
@@ -104,6 +104,7 @@ void ClientMain() {
         // Check for response
         rdmamsg::InboundMessage response = msg_ep->CheckInboundMessage();
         while (response.size > 0) {
+            // FIXME(jim90247): these checks failed!
             DCHECK_EQ(sizeof(unsigned long), response.size);
             DCHECK_EQ(completed_round, *reinterpret_cast<volatile unsigned long *>(response.data));
             completed_round++;

--- a/src/client.cc
+++ b/src/client.cc
@@ -14,11 +14,13 @@ int main(int argc, char **argv) {
 
     const size_t buffer_size = 1 << 24;
     const size_t message_size = 2;
-    char *buffer = new char[buffer_size]();
+    volatile char *buffer = new volatile char[buffer_size]();
 
-    sprintf(buffer, "this is client");
-    sprintf(buffer + 300, "secret");
-    RdmaClient *endpoint = new RdmaClient(nullptr, 0, buffer, buffer_size, 100, 100, IBV_QPT_RC);
+    sprintf(const_cast<char *>(buffer), "this is client");
+    sprintf(const_cast<char *>(buffer + 300), "secret");
+    RdmaClient *endpoint =
+        new RdmaClient(nullptr, 0, reinterpret_cast<volatile unsigned char *>(buffer), buffer_size,
+                       100, 100, IBV_QPT_RC);
     endpoint->Connect("tcp://192.168.223.1:7889");
 
     /*

--- a/src/messaging/rdma_messaging.cc
+++ b/src/messaging/rdma_messaging.cc
@@ -15,7 +15,7 @@ namespace rdmamsg {
 IRdmaMessagingEndpoint::~IRdmaMessagingEndpoint() {}
 
 RdmaWriteMessagingEndpoint::RdmaWriteMessagingEndpoint(IRdmaEndpoint* endpoint,
-                                                       unsigned char* rdma_buffer,
+                                                       volatile unsigned char* rdma_buffer,
                                                        size_t rdma_buffer_size)
     : rdma_buffer_(rdma_buffer),
       outbound_buffer_start_(kMessagingMetadataSize),

--- a/src/messaging/rdma_messaging.cc
+++ b/src/messaging/rdma_messaging.cc
@@ -26,10 +26,10 @@ RdmaWriteMessagingEndpoint::RdmaWriteMessagingEndpoint(IRdmaEndpoint* endpoint,
       inbound_buffer_end_(rdma_buffer_size),
       // Place local inbound buffer tail at the beginning of the rdma buffer
       inbound_buffer_tail_ptr_(
-          reinterpret_cast<size_t*>(rdma_buffer_ + kInboundBufferTailPtrOffset)),
+          reinterpret_cast<volatile size_t*>(rdma_buffer_ + kInboundBufferTailPtrOffset)),
       // Place remote remote buffer tail at the beginning of the rdma buffer
       remote_buffer_tail_ptr_(
-          reinterpret_cast<size_t*>(rdma_buffer_ + kRemoteBufferTailPtrOffset)) {
+          reinterpret_cast<volatile size_t*>(rdma_buffer_ + kRemoteBufferTailPtrOffset)) {
     CHECK_NOTNULL(endpoint);
     CHECK_NOTNULL(rdma_buffer_);
     // Buffer must be large enough to store local and remote inbound buffer tail
@@ -52,8 +52,8 @@ RdmaWriteMessagingEndpoint::RdmaWriteMessagingEndpoint(IRdmaEndpoint* endpoint,
     endpoint_->InitializeFastWrite(0, 2);
 }
 
-void* RdmaWriteMessagingEndpoint::AllocateOutboundMessageBuffer(int message_size) {
-    void* ptr = nullptr;
+volatile void* RdmaWriteMessagingEndpoint::AllocateOutboundMessageBuffer(int message_size) {
+    volatile void* ptr = nullptr;
     const size_t full_message_size = GetFullMessageSize(message_size);
 
     // Allocate a contiguous memory region
@@ -62,9 +62,10 @@ void* RdmaWriteMessagingEndpoint::AllocateOutboundMessageBuffer(int message_size
         // [ooooxxxxxoo]
         if (outbound_buffer_end_ - outbound_buffer_head_ >= full_message_size) {
             // Fill message size
-            *reinterpret_cast<int*>(rdma_buffer_ + outbound_buffer_head_) = message_size;
+            *reinterpret_cast<volatile int*>(rdma_buffer_ + outbound_buffer_head_) = message_size;
 
-            ptr = reinterpret_cast<void*>(rdma_buffer_ + outbound_buffer_head_ + sizeof(int));
+            ptr = reinterpret_cast<volatile void*>(rdma_buffer_ + outbound_buffer_head_ +
+                                                   sizeof(int));
             outbound_buffer_head_ += full_message_size;
 
             // Set trailing byte to 0xff for polling
@@ -74,14 +75,16 @@ void* RdmaWriteMessagingEndpoint::AllocateOutboundMessageBuffer(int message_size
             // remaining buffer size is not enough, poller should automatically wrap around to the
             // start of the buffer.
             if (outbound_buffer_end_ - outbound_buffer_head_ >= GetFullMessageSize(1)) {
-                *reinterpret_cast<int*>(rdma_buffer_ + outbound_buffer_head_) = kWrapMarker;
+                *reinterpret_cast<volatile int*>(rdma_buffer_ + outbound_buffer_head_) =
+                    kWrapMarker;
             }
 
             // Fill message size
-            *reinterpret_cast<int*>(rdma_buffer_ + outbound_buffer_start_) = message_size;
+            *reinterpret_cast<volatile int*>(rdma_buffer_ + outbound_buffer_start_) = message_size;
 
             // Wrap around
-            ptr = reinterpret_cast<void*>(rdma_buffer_ + outbound_buffer_start_ + sizeof(int));
+            ptr = reinterpret_cast<volatile void*>(rdma_buffer_ + outbound_buffer_start_ +
+                                                   sizeof(int));
             outbound_buffer_head_ = outbound_buffer_start_ + full_message_size;
 
             // Set trailing byte to 0xff for polling
@@ -92,9 +95,10 @@ void* RdmaWriteMessagingEndpoint::AllocateOutboundMessageBuffer(int message_size
         // [xooooooxxxx]
         if (outbound_buffer_tail_ - outbound_buffer_head_ >= full_message_size) {
             // Fill message size
-            *reinterpret_cast<int*>(rdma_buffer_ + outbound_buffer_head_) = message_size;
+            *reinterpret_cast<volatile int*>(rdma_buffer_ + outbound_buffer_head_) = message_size;
 
-            ptr = reinterpret_cast<void*>(rdma_buffer_ + outbound_buffer_head_ + sizeof(int));
+            ptr = reinterpret_cast<volatile void*>(rdma_buffer_ + outbound_buffer_head_ +
+                                                   sizeof(int));
             outbound_buffer_head_ += full_message_size;
 
             // Set trailing byte to 0xff for polling
@@ -188,11 +192,11 @@ InboundMessage RdmaWriteMessagingEndpoint::CheckInboundMessage() {
         // message
         inbound_buffer_head_ = inbound_buffer_start_;
     }
-    int message_body_size = *reinterpret_cast<int*>(rdma_buffer_ + inbound_buffer_head_);
+    int message_body_size = *reinterpret_cast<volatile int*>(rdma_buffer_ + inbound_buffer_head_);
     if (message_body_size == kWrapMarker) {
         // Wrap around
         inbound_buffer_head_ = inbound_buffer_start_;
-        message_body_size = *reinterpret_cast<int*>(rdma_buffer_ + inbound_buffer_head_);
+        message_body_size = *reinterpret_cast<volatile int*>(rdma_buffer_ + inbound_buffer_head_);
     }
 
     // Check the offset
@@ -209,7 +213,8 @@ InboundMessage RdmaWriteMessagingEndpoint::CheckInboundMessage() {
 
     size_t data_offset = inbound_buffer_head_ + sizeof(int);
     inbound_buffer_head_ += full_message_size;
-    return {.data = reinterpret_cast<void*>(rdma_buffer_ + data_offset), .size = message_body_size};
+    return {.data = reinterpret_cast<volatile void*>(rdma_buffer_ + data_offset),
+            .size = message_body_size};
 }
 
 size_t RdmaWriteMessagingEndpoint::GetDirtyMemorySize(size_t head, size_t tail, size_t lower_bound,

--- a/src/messaging/rdma_messaging.h
+++ b/src/messaging/rdma_messaging.h
@@ -11,7 +11,7 @@ using std::size_t;
 namespace rdmamsg {
 
 struct InboundMessage {
-    void* data;
+    volatile void* data;
     int size;
 };
 
@@ -27,7 +27,7 @@ class IRdmaMessagingEndpoint {
      * @note Do not free the returned buffer! The returned memory region is not necessarily a new
      * memory buffer allocated via malloc() or similar function.
      */
-    virtual void* AllocateOutboundMessageBuffer(int message_size) = 0;
+    virtual volatile void* AllocateOutboundMessageBuffer(int message_size) = 0;
 
     /**
      * @brief Send all the allocated messages
@@ -65,7 +65,7 @@ class RdmaWriteMessagingEndpoint : public IRdmaMessagingEndpoint {
    public:
     RdmaWriteMessagingEndpoint(IRdmaEndpoint* endpoint, unsigned char* rdma_buffer,
                                size_t rdma_buffer_size);
-    virtual void* AllocateOutboundMessageBuffer(int message_size) override;
+    virtual volatile void* AllocateOutboundMessageBuffer(int message_size) override;
     virtual void ReleaseInboundMessageBuffer() override;
     virtual int64_t FlushOutboundMessage() override;
     virtual void BlockUntilComplete(int64_t flush_id) override;
@@ -80,7 +80,7 @@ class RdmaWriteMessagingEndpoint : public IRdmaMessagingEndpoint {
    private:
     IRdmaEndpoint* endpoint_;
     std::queue<OutboundMessage> outbound_pending_message_;
-    unsigned char* rdma_buffer_;
+    volatile unsigned char* rdma_buffer_;
 
     // When polling size get this number, it means that remaining buffer at the end of the message
     // are empty, and should retry polling again at the start of the buffer
@@ -100,11 +100,11 @@ class RdmaWriteMessagingEndpoint : public IRdmaMessagingEndpoint {
     // Located at the beginning of the rdma buffer. Remote peer can read this value via RDMA READ to
     // know the available memory region of this messaging endpoint.
     const static size_t kInboundBufferTailPtrOffset = 0;
-    size_t* const inbound_buffer_tail_ptr_;
+    volatile size_t* const inbound_buffer_tail_ptr_;
     // Located at the beginning of the rdma buffer, right after inbound buffer tail. We can read the
     // inbound buffer tail of remote peer to this memory using RDMA READ.
     const static size_t kRemoteBufferTailPtrOffset = sizeof(size_t);
-    size_t* const remote_buffer_tail_ptr_;
+    volatile size_t* const remote_buffer_tail_ptr_;
 
     const static int kMaxRefreshCount = 1 << 20;
 

--- a/src/messaging/rdma_messaging.h
+++ b/src/messaging/rdma_messaging.h
@@ -63,7 +63,7 @@ class IRdmaMessagingEndpoint {
 
 class RdmaWriteMessagingEndpoint : public IRdmaMessagingEndpoint {
    public:
-    RdmaWriteMessagingEndpoint(IRdmaEndpoint* endpoint, unsigned char* rdma_buffer,
+    RdmaWriteMessagingEndpoint(IRdmaEndpoint* endpoint, volatile unsigned char* rdma_buffer,
                                size_t rdma_buffer_size);
     virtual volatile void* AllocateOutboundMessageBuffer(int message_size) override;
     virtual void ReleaseInboundMessageBuffer() override;

--- a/src/network/rdma.h
+++ b/src/network/rdma.h
@@ -62,8 +62,8 @@ class RdmaEndpoint : public IRdmaEndpoint {
      * @param max_recv_count Max number of outgoing RECV work requests at the same time.
      * @param qp_type Queue pair type. Default is IBV_QPT_RC.
      */
-    RdmaEndpoint(char *ib_dev_name, uint8_t ib_dev_port, char *buffer, size_t buffer_size,
-                 uint32_t max_send_count, uint32_t max_recv_count,
+    RdmaEndpoint(char *ib_dev_name, uint8_t ib_dev_port, volatile unsigned char *buffer,
+                 size_t buffer_size, uint32_t max_send_count, uint32_t max_recv_count,
                  ibv_qp_type qp_type = IBV_QPT_RC);
     ~RdmaEndpoint();
     uint64_t Write(bool initialized, size_t remote_id, uint64_t local_offset,
@@ -92,8 +92,8 @@ class RdmaEndpoint : public IRdmaEndpoint {
     struct ibv_qp *qp_;
     struct ibv_mr *mr_;
 
-    char *buf_;        // Buffer associated with local memory region
-    size_t buf_size_;  // Size of the buffer associated with local memory region
+    volatile unsigned char *buf_;  // Buffer associated with local memory region
+    size_t buf_size_;              // Size of the buffer associated with local memory region
 
     const static size_t kZmqMessageBufferSize = 1024;
     void *zmq_context_;
@@ -131,8 +131,9 @@ class RdmaEndpoint : public IRdmaEndpoint {
 // wait for clients to connect, implement connect and disconnect
 class RdmaServer : public RdmaEndpoint {
    public:
-    RdmaServer(char *ib_dev_name, uint8_t ib_dev_port, char *buffer, size_t buffer_size,
-               uint32_t max_send_count, uint32_t max_recv_count, ibv_qp_type qp_type);
+    RdmaServer(char *ib_dev_name, uint8_t ib_dev_port, volatile unsigned char *buffer,
+               size_t buffer_size, uint32_t max_send_count, uint32_t max_recv_count,
+               ibv_qp_type qp_type);
     ~RdmaServer();
     void Listen(const char *endpoint);
 };
@@ -140,8 +141,9 @@ class RdmaServer : public RdmaEndpoint {
 // connect to an rdma server
 class RdmaClient : public RdmaEndpoint {
    public:
-    RdmaClient(char *ib_dev_name, uint8_t ib_dev_port, char *buffer, size_t buffer_size,
-               uint32_t max_send_count, uint32_t max_recv_count, ibv_qp_type qp_type);
+    RdmaClient(char *ib_dev_name, uint8_t ib_dev_port, volatile unsigned char *buffer,
+               size_t buffer_size, uint32_t max_send_count, uint32_t max_recv_count,
+               ibv_qp_type qp_type);
     ~RdmaClient();
     void Connect(const char *endpoint);
     void Disconnect();

--- a/src/network/rdma_client.cc
+++ b/src/network/rdma_client.cc
@@ -2,8 +2,9 @@
 
 #include "network/rdma.h"
 
-RdmaClient::RdmaClient(char *ib_dev_name, uint8_t ib_dev_port, char *buffer, size_t buffer_size,
-                       uint32_t max_send_count, uint32_t max_recv_count, ibv_qp_type qp_type)
+RdmaClient::RdmaClient(char *ib_dev_name, uint8_t ib_dev_port, volatile unsigned char *buffer,
+                       size_t buffer_size, uint32_t max_send_count, uint32_t max_recv_count,
+                       ibv_qp_type qp_type)
     : RdmaEndpoint(ib_dev_name, ib_dev_port, buffer, buffer_size, max_send_count, max_recv_count,
                    qp_type) {
     zmq_socket_ = zmq_socket(zmq_context_, ZMQ_REQ);

--- a/src/network/rdma_endpoint.cc
+++ b/src/network/rdma_endpoint.cc
@@ -306,15 +306,12 @@ uint64_t RdmaEndpoint::Write(bool initialized, size_t remote_id, uint64_t local_
     }
 
     // Fill template
-    FillOutWriteWorkRequest(
-        sg_template_, send_wr_template_, remote_id,
-        // seems that the vector construction here consumes significant amount of time.
-        // TODO(jim90247): maybe use a static vector here to hold the incoming value.
-        {std::make_tuple(local_offset, remote_offset, length)}, flags);
+    FillOutWriteWorkRequest(sg_template_, send_wr_template_, remote_id,
+                            {std::make_tuple(local_offset, remote_offset, length)}, flags);
 
     int rc = PostSendWithAutoReclaim(qp_, send_wr_template_);
 
-    LOG_IF(ERROR, rc != 0) << "Error posting IBV_WR_RDMA_WRITE work request: " << strerror(rc);
+    DLOG_IF(ERROR, rc != 0) << "Error posting IBV_WR_RDMA_WRITE work request: " << strerror(rc);
     if (rc == 0 && (flags & IBV_SEND_SIGNALED)) num_signaled_wr_in_progress_ += 1;
 
     return send_wr_template_[0].wr_id;

--- a/src/network/rdma_endpoint.cc
+++ b/src/network/rdma_endpoint.cc
@@ -15,8 +15,9 @@
 
 IRdmaEndpoint::~IRdmaEndpoint() {}
 
-RdmaEndpoint::RdmaEndpoint(char *ib_dev_name, uint8_t ib_dev_port, char *buffer, size_t buffer_size,
-                           uint32_t max_send_count, uint32_t max_recv_count, ibv_qp_type qp_type)
+RdmaEndpoint::RdmaEndpoint(char *ib_dev_name, uint8_t ib_dev_port, volatile unsigned char *buffer,
+                           size_t buffer_size, uint32_t max_send_count, uint32_t max_recv_count,
+                           ibv_qp_type qp_type)
     : ib_dev_port_(ib_dev_port),
       buf_(buffer),
       buf_size_(buffer_size),
@@ -38,7 +39,7 @@ RdmaEndpoint::RdmaEndpoint(char *ib_dev_name, uint8_t ib_dev_port, char *buffer,
     CHECK_EQ(ibv_query_port(ctx_, ib_dev_port_, &ib_dev_port_info_), 0)
         << "Failed to query port " << ib_dev_port_ << " (" << ib_dev_name << ")";
 
-    mr_ = ibv_reg_mr(pd_, buf_, buf_size_,
+    mr_ = ibv_reg_mr(pd_, const_cast<unsigned char *>(buf_), buf_size_,
                      IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_READ | IBV_ACCESS_REMOTE_WRITE);
     CHECK(mr_ != nullptr) << "Failed to register memory region";
 

--- a/src/network/rdma_endpoint.cc
+++ b/src/network/rdma_endpoint.cc
@@ -480,6 +480,7 @@ void RdmaEndpoint::WaitForCompletion(bool poll_until_found, uint64_t target_wr_i
             DLOG_IF(ERROR, wc_list[i].status != IBV_WC_SUCCESS)
                 << "Work request " << wc_list[i].wr_id
                 << " completed with error: " << ibv_wc_status_str(wc_list[i].status);
+            // TODO(jim90247): Use a more efficient way to store completed work request
             completed_wr_.insert(wc_list[i].wr_id);
             num_signaled_wr_in_progress_--;
         }

--- a/src/network/rdma_endpoint.cc
+++ b/src/network/rdma_endpoint.cc
@@ -306,8 +306,11 @@ uint64_t RdmaEndpoint::Write(bool initialized, size_t remote_id, uint64_t local_
     }
 
     // Fill template
-    FillOutWriteWorkRequest(sg_template_, send_wr_template_, remote_id,
-                            {std::make_tuple(local_offset, remote_offset, length)}, flags);
+    FillOutWriteWorkRequest(
+        sg_template_, send_wr_template_, remote_id,
+        // seems that the vector construction here consumes significant amount of time.
+        // TODO(jim90247): maybe use a static vector here to hold the incoming value.
+        {std::make_tuple(local_offset, remote_offset, length)}, flags);
 
     int rc = PostSendWithAutoReclaim(qp_, send_wr_template_);
 

--- a/src/network/rdma_endpoint.cc
+++ b/src/network/rdma_endpoint.cc
@@ -480,7 +480,7 @@ void RdmaEndpoint::WaitForCompletion(bool poll_until_found, uint64_t target_wr_i
             DLOG_IF(ERROR, wc_list[i].status != IBV_WC_SUCCESS)
                 << "Work request " << wc_list[i].wr_id
                 << " completed with error: " << ibv_wc_status_str(wc_list[i].status);
-            // TODO(jim90247): Use a more efficient way to store completed work request
+            // TODO: Use a more efficient way to store completed work request
             completed_wr_.insert(wc_list[i].wr_id);
             num_signaled_wr_in_progress_--;
         }

--- a/src/network/rdma_server.cc
+++ b/src/network/rdma_server.cc
@@ -2,8 +2,9 @@
 
 #include "network/rdma.h"
 
-RdmaServer::RdmaServer(char *ib_dev_name, uint8_t ib_dev_port, char *buffer, size_t buffer_size,
-                       uint32_t max_send_count, uint32_t max_recv_count, ibv_qp_type qp_type)
+RdmaServer::RdmaServer(char *ib_dev_name, uint8_t ib_dev_port, volatile unsigned char *buffer,
+                       size_t buffer_size, uint32_t max_send_count, uint32_t max_recv_count,
+                       ibv_qp_type qp_type)
     : RdmaEndpoint(ib_dev_name, ib_dev_port, buffer, buffer_size, max_send_count, max_recv_count,
                    qp_type) {
     zmq_socket_ = zmq_socket(zmq_context_, ZMQ_REP);

--- a/src/server.cc
+++ b/src/server.cc
@@ -16,10 +16,12 @@ int main(int argc, char **argv) {
 
     const size_t buffer_size = 1 << 23;
     const size_t message_size = 2;
-    char *buffer = new char[buffer_size]();
-    sprintf(buffer + 100, "this is server");
+    volatile char *buffer = new volatile char[buffer_size]();
+    sprintf(const_cast<char *>(buffer + 100), "this is server");
 
-    RdmaServer *endpoint = new RdmaServer(nullptr, 0, buffer, buffer_size, 128, 128, IBV_QPT_RC);
+    RdmaServer *endpoint =
+        new RdmaServer(nullptr, 0, reinterpret_cast<volatile unsigned char *>(buffer), buffer_size,
+                       128, 128, IBV_QPT_RC);
     endpoint->Listen("tcp://192.168.223.1:7889");
 
     uint64_t wr_id, wr_id2;


### PR DESCRIPTION
- Measure the messaging latency at client side with a period defined by `kLatencyMeasurePeriod`.
- Add `volatile` qualifier on RDMA buffer to prevent compiler from optimizing out codes that operate on the buffer.
- Add a TODO for improving the efficiency of recording completed work requests. Experiment shows that the `unordered_set` operations greatly impact the latency.